### PR TITLE
Feature/pricing engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ replay_pid*
 .kotlin/
 
 **/.DS_Store
+
+# pricing_engine related
+pricing_engine/src/*.o
+
+pricing_engine/pricing_engine

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ replay_pid*
 **/.DS_Store
 
 # pricing_engine related
+pricing_engine/.cache
 pricing_engine/src/*.o
-
 pricing_engine/pricing_engine
+
+# db related
+clickhouse_data
+clickhouse_logs

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,8 @@
+# Инициализация Clickhouse DB для котировок
+
+> Используем единожды для создания таблицы
+
+```bash
+docker compose up -d
+./db/clickhouse/init_clickhouse.sh
+```

--- a/db/clickhouse/init.sql
+++ b/db/clickhouse/init.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS quotes
+(
+    schema_version UInt8,
+    sequence UInt64,
+
+    event_type LowCardinality(String),
+    quote_type LowCardinality(String),
+
+    event_time_ns UInt64,
+    engine_time_ns UInt64,
+
+    scenario_id LowCardinality(String),
+    venue LowCardinality(String),
+    symbol LowCardinality(String),
+
+    bid_price Float64,
+    bid_size Float64,
+    ask_price Float64,
+    ask_size Float64,
+
+    mid_price Float64,
+    spread Float64,
+
+    last_price Float64,
+    last_size Float64,
+    last_trade_side LowCardinality(String)
+)
+ENGINE = MergeTree
+ORDER BY (symbol, event_time_ns, sequence);

--- a/db/clickhouse/init_clickhouse.sh
+++ b/db/clickhouse/init_clickhouse.sh
@@ -1,0 +1,1 @@
+cat db/clickhouse/init.sql | docker exec -i clickhouse-local clickhouse-client

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  clickhouse:
+    image: clickhouse/clickhouse-server:latest
+    container_name: clickhouse-local
+    ports:
+      - "8123:8123"
+      - "9000:9000"
+    volumes:
+      - ./clickhouse_data:/var/lib/clickhouse
+      - ./clickhouse_logs:/var/log/clickhouse-server
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144

--- a/pricing_engine/Makefile
+++ b/pricing_engine/Makefile
@@ -1,0 +1,23 @@
+CC = cc
+CFLAGS = -std=c11 -Wall -Wextra -Werror -pedantic -Iinclude
+LDFLAGS =
+
+SRC = \
+	src/main.c \
+	src/scenario.c \
+	src/generator.c \
+	src/rng.c \
+	src/json_writer.c
+
+OBJ = $(SRC:.c=.o)
+TARGET = pricing_engine
+
+all: $(TARGET)
+
+$(TARGET): $(OBJ)
+	$(CC) $(OBJ) -o $@ $(LDFLAGS)
+
+clean:
+	rm -f $(OBJ) $(TARGET)
+
+.PHONY: all clean

--- a/pricing_engine/README.md
+++ b/pricing_engine/README.md
@@ -9,7 +9,7 @@ Minimal C pricing engine that:
 
 ```bash
 make
-```
+````
 
 ## Run
 
@@ -41,27 +41,64 @@ steps:
 ```
 
 Supported top-level fields:
-- `scenario_id`
-- `venue`
-- `symbol`
-- `seed`
-- `start_time_ns`
-- `tick_interval_ms`
-- `initial_mid_price`
-- `initial_spread`
-- `default_bid_size`
-- `default_ask_size`
-- `default_last_size`
-- `steps`
+
+* `scenario_id`
+* `venue`
+* `symbol`
+* `seed`
+* `start_time_ns`
+* `tick_interval_ms`
+* `initial_mid_price`
+* `initial_spread`
+* `default_bid_size`
+* `default_ask_size`
+* `default_last_size`
+* `steps`
 
 Supported step fields:
-- `move_mid_by`
-- `spread`
-- `bid_size`
-- `ask_size`
-- `last_size`
-- `trade_side` (`buy`, `sell`, `none`)
+
+* `move_mid_by`
+* `spread`
+* `bid_size`
+* `ask_size`
+* `last_size`
+* `trade_side` (`buy`, `sell`, `none`)
 
 ## Output
 
 Each line is one JSON quote event.
+
+---
+
+## ClickHouse integration (local)
+
+The engine outputs NDJSON, which can be directly piped into ClickHouse using `JSONEachRow`.
+
+### 1. Run ClickHouse via Docker
+
+```bash
+docker compose up -d
+```
+
+### 2. Initialize schema
+
+```bash
+cat db/init.sql | docker exec -i clickhouse-local clickhouse-client
+```
+
+### 3. Push data to DB
+
+Run pipeline:
+
+```bash
+./pricing_engine --scenario examples/basic_btc.yaml | ./push_input_to_db.sh
+```
+
+---
+
+## Notes
+
+* NDJSON output is fully compatible with ClickHouse `JSONEachRow`
+* Table schema must match JSON fields (`init.sql`)
+* If Docker volume is removed (`docker compose down -v`), schema must be re-initialized
+

--- a/pricing_engine/README.md
+++ b/pricing_engine/README.md
@@ -1,0 +1,67 @@
+# pricing_engine
+
+Minimal C pricing engine that:
+- loads deterministic test scenarios from YAML
+- generates quote events
+- prints NDJSON to stdout
+
+## Build
+
+```bash
+make
+```
+
+## Run
+
+```bash
+./pricing_engine --scenario examples/basic_btc.yaml
+./pricing_engine --scenario examples/basic_btc.yaml --limit 2
+```
+
+## YAML scenario format
+
+```yaml
+scenario_id: basic_btc_regression
+venue: BINANCE
+symbol: BTCUSDT
+seed: 42
+start_time_ns: 1713439200000000000
+tick_interval_ms: 100
+initial_mid_price: 65000.0
+initial_spread: 0.50
+default_bid_size: 1.20
+default_ask_size: 1.00
+default_last_size: 0.10
+steps:
+  - move_mid_by: 0.25
+    bid_size: 1.10
+    ask_size: 0.90
+    last_size: 0.05
+    trade_side: buy
+```
+
+Supported top-level fields:
+- `scenario_id`
+- `venue`
+- `symbol`
+- `seed`
+- `start_time_ns`
+- `tick_interval_ms`
+- `initial_mid_price`
+- `initial_spread`
+- `default_bid_size`
+- `default_ask_size`
+- `default_last_size`
+- `steps`
+
+Supported step fields:
+- `move_mid_by`
+- `spread`
+- `bid_size`
+- `ask_size`
+- `last_size`
+- `trade_side` (`buy`, `sell`, `none`)
+
+## Output
+
+Each line is one JSON quote event.

--- a/pricing_engine/README_ru.md
+++ b/pricing_engine/README_ru.md
@@ -1,16 +1,15 @@
 # pricing_engine
 
 Минимальный pricing engine на C, который:
-
-* загружает детерминированные тестовые сценарии из YAML
-* генерирует события котировок
-* выводит NDJSON в stdout
+- загружает детерминированные тестовые сценарии из YAML
+- генерирует события котировок
+- выводит NDJSON в stdout
 
 ## Сборка
 
 ```bash
 make
-```
+````
 
 ## Запуск
 
@@ -67,4 +66,39 @@ steps:
 
 ## Выходные данные
 
-Каждая строка — это одно JSON-событие котировки.
+Каждая строка — одно JSON-событие котировки.
+
+---
+
+## Интеграция с ClickHouse (локально)
+
+Выход программы — NDJSON, который можно напрямую отправлять в ClickHouse через формат `JSONEachRow`.
+
+### 1. Запуск ClickHouse в Docker
+
+```bash
+docker compose up -d
+```
+
+### 2. Инициализация схемы
+
+```bash
+cat db/init.sql | docker exec -i clickhouse-local clickhouse-client
+```
+
+### 3. Отправка данных в БД
+
+Запуск пайплайна:
+
+```bash
+./pricing_engine --scenario examples/basic_btc.yaml | ./push_input_to_db.sh
+```
+
+---
+
+## Примечания
+
+* NDJSON полностью совместим с форматом ClickHouse `JSONEachRow`
+* схема таблицы должна совпадать с JSON (`init.sql`)
+* при удалении volume (`docker compose down -v`) таблицу нужно создать заново
+

--- a/pricing_engine/README_ru.md
+++ b/pricing_engine/README_ru.md
@@ -1,0 +1,70 @@
+# pricing_engine
+
+Минимальный pricing engine на C, который:
+
+* загружает детерминированные тестовые сценарии из YAML
+* генерирует события котировок
+* выводит NDJSON в stdout
+
+## Сборка
+
+```bash
+make
+```
+
+## Запуск
+
+```bash
+./pricing_engine --scenario examples/basic_btc.yaml
+./pricing_engine --scenario examples/basic_btc.yaml --limit 2
+```
+
+## Формат YAML-сценария
+
+```yaml
+scenario_id: basic_btc_regression
+venue: BINANCE
+symbol: BTCUSDT
+seed: 42
+start_time_ns: 1713439200000000000
+tick_interval_ms: 100
+initial_mid_price: 65000.0
+initial_spread: 0.50
+default_bid_size: 1.20
+default_ask_size: 1.00
+default_last_size: 0.10
+steps:
+  - move_mid_by: 0.25
+    bid_size: 1.10
+    ask_size: 0.90
+    last_size: 0.05
+    trade_side: buy
+```
+
+Поддерживаемые поля верхнего уровня:
+
+* `scenario_id`
+* `venue`
+* `symbol`
+* `seed`
+* `start_time_ns`
+* `tick_interval_ms`
+* `initial_mid_price`
+* `initial_spread`
+* `default_bid_size`
+* `default_ask_size`
+* `default_last_size`
+* `steps`
+
+Поддерживаемые поля шага:
+
+* `move_mid_by`
+* `spread`
+* `bid_size`
+* `ask_size`
+* `last_size`
+* `trade_side` (`buy`, `sell`, `none`)
+
+## Выходные данные
+
+Каждая строка — это одно JSON-событие котировки.

--- a/pricing_engine/compile_commands.json
+++ b/pricing_engine/compile_commands.json
@@ -1,0 +1,92 @@
+[
+  {
+    "file": "src/main.c",
+    "arguments": [
+      "cc",
+      "-std=c11",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-pedantic",
+      "-Iinclude",
+      "-c",
+      "-o",
+      "src/main.o",
+      "src/main.c"
+    ],
+    "directory": "/home/theodor/my-coding/school/TrumpInvestitions/pricing_engine",
+    "output": "src/main.o"
+  },
+  {
+    "file": "src/scenario.c",
+    "arguments": [
+      "cc",
+      "-std=c11",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-pedantic",
+      "-Iinclude",
+      "-c",
+      "-o",
+      "src/scenario.o",
+      "src/scenario.c"
+    ],
+    "directory": "/home/theodor/my-coding/school/TrumpInvestitions/pricing_engine",
+    "output": "src/scenario.o"
+  },
+  {
+    "file": "src/generator.c",
+    "arguments": [
+      "cc",
+      "-std=c11",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-pedantic",
+      "-Iinclude",
+      "-c",
+      "-o",
+      "src/generator.o",
+      "src/generator.c"
+    ],
+    "directory": "/home/theodor/my-coding/school/TrumpInvestitions/pricing_engine",
+    "output": "src/generator.o"
+  },
+  {
+    "file": "src/rng.c",
+    "arguments": [
+      "cc",
+      "-std=c11",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-pedantic",
+      "-Iinclude",
+      "-c",
+      "-o",
+      "src/rng.o",
+      "src/rng.c"
+    ],
+    "directory": "/home/theodor/my-coding/school/TrumpInvestitions/pricing_engine",
+    "output": "src/rng.o"
+  },
+  {
+    "file": "src/json_writer.c",
+    "arguments": [
+      "cc",
+      "-std=c11",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-pedantic",
+      "-Iinclude",
+      "-c",
+      "-o",
+      "src/json_writer.o",
+      "src/json_writer.c"
+    ],
+    "directory": "/home/theodor/my-coding/school/TrumpInvestitions/pricing_engine",
+    "output": "src/json_writer.o"
+  }
+]

--- a/pricing_engine/examples/basic_btc.yaml
+++ b/pricing_engine/examples/basic_btc.yaml
@@ -1,0 +1,33 @@
+scenario_id: basic_btc_regression
+venue: BINANCE
+symbol: BTCUSDT
+seed: 42
+start_time_ns: 1713439200000000000
+tick_interval_ms: 100
+initial_mid_price: 65000.0
+initial_spread: 0.50
+default_bid_size: 1.20
+default_ask_size: 1.00
+default_last_size: 0.10
+steps:
+  - move_mid_by: 0.25
+    bid_size: 1.10
+    ask_size: 0.90
+    last_size: 0.05
+    trade_side: buy
+  - move_mid_by: -0.10
+    bid_size: 1.40
+    ask_size: 1.20
+    last_size: 0.08
+    trade_side: sell
+  - move_mid_by: 0.35
+    spread: 0.60
+    bid_size: 1.30
+    ask_size: 1.10
+    last_size: 0.12
+    trade_side: buy
+  - move_mid_by: 0.00
+    bid_size: 1.00
+    ask_size: 1.50
+    last_size: 0.00
+    trade_side: none

--- a/pricing_engine/include/generator.h
+++ b/pricing_engine/include/generator.h
@@ -1,0 +1,19 @@
+#ifndef GENERATOR_H
+#define GENERATOR_H
+
+#include "rng.h"
+#include "types.h"
+
+typedef struct {
+    PeScenario scenario;
+    PeRng rng;
+    size_t next_step_index;
+    uint64_t next_sequence;
+    uint64_t next_event_time_ns;
+    double current_mid_price;
+} PeGenerator;
+
+void pe_generator_init(PeGenerator *gen, const PeScenario *scenario);
+int pe_generator_next(PeGenerator *gen, PeQuoteEvent *out_event);
+
+#endif

--- a/pricing_engine/include/json_writer.h
+++ b/pricing_engine/include/json_writer.h
@@ -1,0 +1,10 @@
+#ifndef JSON_WRITER_H
+#define JSON_WRITER_H
+
+#include <stdio.h>
+
+#include "types.h"
+
+void pe_quote_event_write_json(FILE *out, const PeQuoteEvent *event);
+
+#endif

--- a/pricing_engine/include/rng.h
+++ b/pricing_engine/include/rng.h
@@ -1,0 +1,14 @@
+#ifndef RNG_H
+#define RNG_H
+
+#include <stdint.h>
+
+typedef struct {
+    uint64_t state;
+} PeRng;
+
+void pe_rng_init(PeRng *rng, uint64_t seed);
+uint64_t pe_rng_next_u64(PeRng *rng);
+double pe_rng_next_unit(PeRng *rng);
+
+#endif

--- a/pricing_engine/include/scenario.h
+++ b/pricing_engine/include/scenario.h
@@ -1,0 +1,8 @@
+#ifndef SCENARIO_H
+#define SCENARIO_H
+
+#include "types.h"
+
+int pe_scenario_load_from_file(const char *path, PeScenario *out_scenario, char *errbuf, size_t errbuf_size);
+
+#endif

--- a/pricing_engine/include/types.h
+++ b/pricing_engine/include/types.h
@@ -1,0 +1,68 @@
+#ifndef TYPES_H
+#define TYPES_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define PE_MAX_ID_LEN 64
+#define PE_MAX_SYMBOL_LEN 32
+#define PE_MAX_VENUE_LEN 32
+#define PE_MAX_STEPS 10000
+
+typedef enum {
+    PE_TRADE_NONE = 0,
+    PE_TRADE_BUY = 1,
+    PE_TRADE_SELL = 2
+} PeTradeSide;
+
+typedef enum {
+    PE_QUOTE_SNAPSHOT = 0,
+    PE_QUOTE_UPDATE = 1
+} PeQuoteType;
+
+typedef struct {
+    double move_mid_by;
+    double spread;
+    double bid_size;
+    double ask_size;
+    double last_size;
+    PeTradeSide trade_side;
+} PeScenarioStep;
+
+typedef struct {
+    char scenario_id[PE_MAX_ID_LEN];
+    char venue[PE_MAX_VENUE_LEN];
+    char symbol[PE_MAX_SYMBOL_LEN];
+    uint64_t seed;
+    uint64_t start_time_ns;
+    uint64_t tick_interval_ms;
+    double initial_mid_price;
+    double initial_spread;
+    double default_bid_size;
+    double default_ask_size;
+    double default_last_size;
+    size_t step_count;
+    PeScenarioStep steps[PE_MAX_STEPS];
+} PeScenario;
+
+typedef struct {
+    uint64_t schema_version;
+    uint64_t sequence;
+    uint64_t event_time_ns;
+    uint64_t engine_time_ns;
+    char scenario_id[PE_MAX_ID_LEN];
+    char venue[PE_MAX_VENUE_LEN];
+    char symbol[PE_MAX_SYMBOL_LEN];
+    PeQuoteType quote_type;
+    double bid_price;
+    double bid_size;
+    double ask_price;
+    double ask_size;
+    double mid_price;
+    double spread;
+    double last_price;
+    double last_size;
+    PeTradeSide last_trade_side;
+} PeQuoteEvent;
+
+#endif

--- a/pricing_engine/push_input_to_db.sh
+++ b/pricing_engine/push_input_to_db.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker exec -i clickhouse-local clickhouse-client \
+  --query="INSERT INTO quotes FORMAT JSONEachRow"

--- a/pricing_engine/src/generator.c
+++ b/pricing_engine/src/generator.c
@@ -1,0 +1,81 @@
+#define _POSIX_C_SOURCE 200809L
+#include "generator.h"
+
+#include <string.h>
+#include <time.h>
+
+static uint64_t pe_now_ns(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+}
+
+void pe_generator_init(PeGenerator *gen, const PeScenario *scenario) {
+    memset(gen, 0, sizeof(*gen));
+    gen->scenario = *scenario;
+    pe_rng_init(&gen->rng, scenario->seed);
+    gen->next_step_index = 0;
+    gen->next_sequence = 1;
+    gen->next_event_time_ns = scenario->start_time_ns;
+    gen->current_mid_price = scenario->initial_mid_price;
+}
+
+int pe_generator_next(PeGenerator *gen, PeQuoteEvent *out_event) {
+    if (gen->next_step_index >= gen->scenario.step_count) {
+        return 0;
+    }
+
+    const PeScenarioStep *step = &gen->scenario.steps[gen->next_step_index];
+    double effective_spread = step->spread > 0.0 ? step->spread : gen->scenario.initial_spread;
+    double bid_price;
+    double ask_price;
+    double last_price;
+
+    gen->current_mid_price += step->move_mid_by;
+    if (gen->current_mid_price <= 0.0) {
+        gen->current_mid_price = 0.00000001;
+    }
+    if (effective_spread <= 0.0) {
+        effective_spread = 0.00000001;
+    }
+
+    bid_price = gen->current_mid_price - effective_spread / 2.0;
+    ask_price = gen->current_mid_price + effective_spread / 2.0;
+
+    switch (step->trade_side) {
+        case PE_TRADE_BUY:
+            last_price = ask_price;
+            break;
+        case PE_TRADE_SELL:
+            last_price = bid_price;
+            break;
+        case PE_TRADE_NONE:
+        default:
+            last_price = gen->current_mid_price;
+            break;
+    }
+
+    memset(out_event, 0, sizeof(*out_event));
+    out_event->schema_version = 1;
+    out_event->sequence = gen->next_sequence;
+    out_event->event_time_ns = gen->next_event_time_ns;
+    out_event->engine_time_ns = pe_now_ns();
+    out_event->quote_type = (gen->next_step_index == 0) ? PE_QUOTE_SNAPSHOT : PE_QUOTE_UPDATE;
+    out_event->bid_price = bid_price;
+    out_event->bid_size = step->bid_size;
+    out_event->ask_price = ask_price;
+    out_event->ask_size = step->ask_size;
+    out_event->mid_price = gen->current_mid_price;
+    out_event->spread = effective_spread;
+    out_event->last_price = last_price;
+    out_event->last_size = step->last_size;
+    out_event->last_trade_side = step->trade_side;
+    memcpy(out_event->scenario_id, gen->scenario.scenario_id, sizeof(out_event->scenario_id));
+    memcpy(out_event->venue, gen->scenario.venue, sizeof(out_event->venue));
+    memcpy(out_event->symbol, gen->scenario.symbol, sizeof(out_event->symbol));
+
+    gen->next_sequence += 1;
+    gen->next_step_index += 1;
+    gen->next_event_time_ns += gen->scenario.tick_interval_ms * 1000000ULL;
+    return 1;
+}

--- a/pricing_engine/src/json_writer.c
+++ b/pricing_engine/src/json_writer.c
@@ -1,0 +1,60 @@
+#include "json_writer.h"
+
+#include <stdio.h>
+
+static const char *pe_quote_type_name(PeQuoteType value) {
+    return value == PE_QUOTE_SNAPSHOT ? "snapshot" : "update";
+}
+
+static const char *pe_trade_side_name(PeTradeSide value) {
+    switch (value) {
+        case PE_TRADE_BUY:
+            return "buy";
+        case PE_TRADE_SELL:
+            return "sell";
+        case PE_TRADE_NONE:
+        default:
+            return "none";
+    }
+}
+
+void pe_quote_event_write_json(FILE *out, const PeQuoteEvent *event) {
+    fprintf(out,
+            "{"
+            "\"schema_version\":%llu,"
+            "\"sequence\":%llu,"
+            "\"event_type\":\"quote\","
+            "\"quote_type\":\"%s\","
+            "\"event_time_ns\":%llu,"
+            "\"engine_time_ns\":%llu,"
+            "\"scenario_id\":\"%s\","
+            "\"venue\":\"%s\","
+            "\"symbol\":\"%s\","
+            "\"bid_price\":%.10f,"
+            "\"bid_size\":%.10f,"
+            "\"ask_price\":%.10f,"
+            "\"ask_size\":%.10f,"
+            "\"mid_price\":%.10f,"
+            "\"spread\":%.10f,"
+            "\"last_price\":%.10f,"
+            "\"last_size\":%.10f,"
+            "\"last_trade_side\":\"%s\""
+            "}\n",
+            (unsigned long long)event->schema_version,
+            (unsigned long long)event->sequence,
+            pe_quote_type_name(event->quote_type),
+            (unsigned long long)event->event_time_ns,
+            (unsigned long long)event->engine_time_ns,
+            event->scenario_id,
+            event->venue,
+            event->symbol,
+            event->bid_price,
+            event->bid_size,
+            event->ask_price,
+            event->ask_size,
+            event->mid_price,
+            event->spread,
+            event->last_price,
+            event->last_size,
+            pe_trade_side_name(event->last_trade_side));
+}

--- a/pricing_engine/src/main.c
+++ b/pricing_engine/src/main.c
@@ -1,0 +1,75 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "generator.h"
+#include "json_writer.h"
+#include "scenario.h"
+
+static void pe_print_usage(FILE *out, const char *argv0) {
+    fprintf(out, "Usage: %s --scenario <path> [--limit N]\n", argv0);
+}
+
+int main(int argc, char **argv) {
+    const char *scenario_path = NULL;
+    long long limit = -1;
+    int i;
+    PeScenario scenario;
+    PeGenerator generator;
+    PeQuoteEvent event;
+    char errbuf[256];
+    long long emitted = 0;
+
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--scenario") == 0) {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "missing value for --scenario\n");
+                pe_print_usage(stderr, argv[0]);
+                return 1;
+            }
+            scenario_path = argv[++i];
+            continue;
+        }
+        if (strcmp(argv[i], "--limit") == 0) {
+            char *endptr;
+            if (i + 1 >= argc) {
+                fprintf(stderr, "missing value for --limit\n");
+                pe_print_usage(stderr, argv[0]);
+                return 1;
+            }
+            limit = strtoll(argv[++i], &endptr, 10);
+            if (*endptr != '\0' || limit < 0) {
+                fprintf(stderr, "invalid value for --limit\n");
+                return 1;
+            }
+            continue;
+        }
+        if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+            pe_print_usage(stdout, argv[0]);
+            return 0;
+        }
+        fprintf(stderr, "unknown argument: %s\n", argv[i]);
+        pe_print_usage(stderr, argv[0]);
+        return 1;
+    }
+
+    if (scenario_path == NULL) {
+        fprintf(stderr, "scenario file is required\n");
+        pe_print_usage(stderr, argv[0]);
+        return 1;
+    }
+
+    if (!pe_scenario_load_from_file(scenario_path, &scenario, errbuf, sizeof(errbuf))) {
+        fprintf(stderr, "scenario error: %s\n", errbuf);
+        return 1;
+    }
+
+    pe_generator_init(&generator, &scenario);
+
+    while ((limit < 0 || emitted < limit) && pe_generator_next(&generator, &event)) {
+        pe_quote_event_write_json(stdout, &event);
+        emitted++;
+    }
+
+    return 0;
+}

--- a/pricing_engine/src/rng.c
+++ b/pricing_engine/src/rng.c
@@ -1,0 +1,22 @@
+#include "rng.h"
+
+void pe_rng_init(PeRng *rng, uint64_t seed) {
+    if (seed == 0) {
+        seed = 0x9E3779B97F4A7C15ULL;
+    }
+    rng->state = seed;
+}
+
+uint64_t pe_rng_next_u64(PeRng *rng) {
+    uint64_t x = rng->state;
+    x ^= x >> 12;
+    x ^= x << 25;
+    x ^= x >> 27;
+    rng->state = x;
+    return x * 0x2545F4914F6CDD1DULL;
+}
+
+double pe_rng_next_unit(PeRng *rng) {
+    const uint64_t value = pe_rng_next_u64(rng) >> 11;
+    return (double)value / 9007199254740992.0;
+}

--- a/pricing_engine/src/scenario.c
+++ b/pricing_engine/src/scenario.c
@@ -1,0 +1,285 @@
+#include "scenario.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void pe_set_error(char *errbuf, size_t errbuf_size, const char *message) {
+    if (errbuf == NULL || errbuf_size == 0) {
+        return;
+    }
+    snprintf(errbuf, errbuf_size, "%s", message);
+}
+
+static char *pe_trim(char *s) {
+    char *end;
+    while (*s != '\0' && isspace((unsigned char)*s)) {
+        s++;
+    }
+    if (*s == '\0') {
+        return s;
+    }
+    end = s + strlen(s) - 1;
+    while (end > s && isspace((unsigned char)*end)) {
+        *end = '\0';
+        end--;
+    }
+    return s;
+}
+
+static int pe_parse_u64(const char *value, uint64_t *out) {
+    char *endptr;
+    unsigned long long parsed;
+    parsed = strtoull(value, &endptr, 10);
+    if (endptr == value || *pe_trim(endptr) != '\0') {
+        return 0;
+    }
+    *out = (uint64_t)parsed;
+    return 1;
+}
+
+static int pe_parse_double(const char *value, double *out) {
+    char *endptr;
+    double parsed;
+    parsed = strtod(value, &endptr);
+    if (endptr == value || *pe_trim(endptr) != '\0') {
+        return 0;
+    }
+    *out = parsed;
+    return 1;
+}
+
+static int pe_parse_trade_side(const char *value, PeTradeSide *out) {
+    if (strcmp(value, "buy") == 0) {
+        *out = PE_TRADE_BUY;
+        return 1;
+    }
+    if (strcmp(value, "sell") == 0) {
+        *out = PE_TRADE_SELL;
+        return 1;
+    }
+    if (strcmp(value, "none") == 0) {
+        *out = PE_TRADE_NONE;
+        return 1;
+    }
+    return 0;
+}
+
+static int pe_assign_top_level(PeScenario *scenario, const char *key, const char *value) {
+    if (strcmp(key, "scenario_id") == 0) {
+        snprintf(scenario->scenario_id, sizeof(scenario->scenario_id), "%s", value);
+        return 1;
+    }
+    if (strcmp(key, "venue") == 0) {
+        snprintf(scenario->venue, sizeof(scenario->venue), "%s", value);
+        return 1;
+    }
+    if (strcmp(key, "symbol") == 0) {
+        snprintf(scenario->symbol, sizeof(scenario->symbol), "%s", value);
+        return 1;
+    }
+    if (strcmp(key, "seed") == 0) {
+        return pe_parse_u64(value, &scenario->seed);
+    }
+    if (strcmp(key, "start_time_ns") == 0) {
+        return pe_parse_u64(value, &scenario->start_time_ns);
+    }
+    if (strcmp(key, "tick_interval_ms") == 0) {
+        return pe_parse_u64(value, &scenario->tick_interval_ms);
+    }
+    if (strcmp(key, "initial_mid_price") == 0) {
+        return pe_parse_double(value, &scenario->initial_mid_price);
+    }
+    if (strcmp(key, "initial_spread") == 0) {
+        return pe_parse_double(value, &scenario->initial_spread);
+    }
+    if (strcmp(key, "default_bid_size") == 0) {
+        return pe_parse_double(value, &scenario->default_bid_size);
+    }
+    if (strcmp(key, "default_ask_size") == 0) {
+        return pe_parse_double(value, &scenario->default_ask_size);
+    }
+    if (strcmp(key, "default_last_size") == 0) {
+        return pe_parse_double(value, &scenario->default_last_size);
+    }
+    return 0;
+}
+
+static int pe_assign_step_field(PeScenarioStep *step, const char *key, const char *value) {
+    if (strcmp(key, "move_mid_by") == 0) {
+        return pe_parse_double(value, &step->move_mid_by);
+    }
+    if (strcmp(key, "spread") == 0) {
+        return pe_parse_double(value, &step->spread);
+    }
+    if (strcmp(key, "bid_size") == 0) {
+        return pe_parse_double(value, &step->bid_size);
+    }
+    if (strcmp(key, "ask_size") == 0) {
+        return pe_parse_double(value, &step->ask_size);
+    }
+    if (strcmp(key, "last_size") == 0) {
+        return pe_parse_double(value, &step->last_size);
+    }
+    if (strcmp(key, "trade_side") == 0) {
+        return pe_parse_trade_side(value, &step->trade_side);
+    }
+    return 0;
+}
+
+int pe_scenario_load_from_file(const char *path, PeScenario *out_scenario, char *errbuf, size_t errbuf_size) {
+    FILE *fp;
+    char raw_line[512];
+    unsigned long line_no = 0;
+    int in_steps = 0;
+    PeScenario scenario;
+    PeScenarioStep *current_step = NULL;
+
+    memset(&scenario, 0, sizeof(scenario));
+    snprintf(scenario.scenario_id, sizeof(scenario.scenario_id), "default_scenario");
+    snprintf(scenario.venue, sizeof(scenario.venue), "SIM");
+    scenario.tick_interval_ms = 100;
+    scenario.default_bid_size = 1.0;
+    scenario.default_ask_size = 1.0;
+    scenario.default_last_size = 0.1;
+    scenario.initial_spread = 0.01;
+
+    fp = fopen(path, "r");
+    if (fp == NULL) {
+        pe_set_error(errbuf, errbuf_size, "failed to open scenario file");
+        return 0;
+    }
+
+    while (fgets(raw_line, sizeof(raw_line), fp) != NULL) {
+        char *line;
+        char *colon;
+        int indent = 0;
+        line_no++;
+
+        raw_line[strcspn(raw_line, "\r\n")] = '\0';
+        line = raw_line;
+        while (*line == ' ') {
+            indent++;
+            line++;
+        }
+        line = pe_trim(line);
+        if (*line == '\0' || *line == '#') {
+            continue;
+        }
+
+        if (!in_steps) {
+            if (strcmp(line, "steps:") == 0) {
+                in_steps = 1;
+                continue;
+            }
+
+            colon = strchr(line, ':');
+            if (colon == NULL) {
+                snprintf(errbuf, errbuf_size, "line %lu: expected key: value", line_no);
+                fclose(fp);
+                return 0;
+            }
+            *colon = '\0';
+            {
+                char *key = pe_trim(line);
+                char *value = pe_trim(colon + 1);
+                if (!pe_assign_top_level(&scenario, key, value)) {
+                    snprintf(errbuf, errbuf_size, "line %lu: invalid top-level field '%s'", line_no, key);
+                    fclose(fp);
+                    return 0;
+                }
+            }
+            continue;
+        }
+
+        if (indent < 2) {
+            snprintf(errbuf, errbuf_size, "line %lu: step fields must be indented", line_no);
+            fclose(fp);
+            return 0;
+        }
+
+        if (line[0] == '-') {
+            char *item = pe_trim(line + 1);
+            if (scenario.step_count >= PE_MAX_STEPS) {
+                pe_set_error(errbuf, errbuf_size, "too many steps in scenario");
+                fclose(fp);
+                return 0;
+            }
+            current_step = &scenario.steps[scenario.step_count++];
+            memset(current_step, 0, sizeof(*current_step));
+            current_step->spread = scenario.initial_spread;
+            current_step->bid_size = scenario.default_bid_size;
+            current_step->ask_size = scenario.default_ask_size;
+            current_step->last_size = scenario.default_last_size;
+            current_step->trade_side = PE_TRADE_NONE;
+
+            if (*item == '\0') {
+                continue;
+            }
+
+            colon = strchr(item, ':');
+            if (colon == NULL) {
+                snprintf(errbuf, errbuf_size, "line %lu: expected - key: value", line_no);
+                fclose(fp);
+                return 0;
+            }
+            *colon = '\0';
+            {
+                char *key = pe_trim(item);
+                char *value = pe_trim(colon + 1);
+                if (!pe_assign_step_field(current_step, key, value)) {
+                    snprintf(errbuf, errbuf_size, "line %lu: invalid step field '%s'", line_no, key);
+                    fclose(fp);
+                    return 0;
+                }
+            }
+            continue;
+        }
+
+        if (current_step == NULL) {
+            snprintf(errbuf, errbuf_size, "line %lu: step field without list item", line_no);
+            fclose(fp);
+            return 0;
+        }
+
+        colon = strchr(line, ':');
+        if (colon == NULL) {
+            snprintf(errbuf, errbuf_size, "line %lu: expected key: value", line_no);
+            fclose(fp);
+            return 0;
+        }
+        *colon = '\0';
+        {
+            char *key = pe_trim(line);
+            char *value = pe_trim(colon + 1);
+            if (!pe_assign_step_field(current_step, key, value)) {
+                snprintf(errbuf, errbuf_size, "line %lu: invalid step field '%s'", line_no, key);
+                fclose(fp);
+                return 0;
+            }
+        }
+    }
+
+    fclose(fp);
+
+    if (scenario.symbol[0] == '\0') {
+        pe_set_error(errbuf, errbuf_size, "scenario must define symbol");
+        return 0;
+    }
+    if (scenario.start_time_ns == 0) {
+        pe_set_error(errbuf, errbuf_size, "scenario must define start_time_ns");
+        return 0;
+    }
+    if (scenario.initial_mid_price <= 0.0) {
+        pe_set_error(errbuf, errbuf_size, "scenario must define positive initial_mid_price");
+        return 0;
+    }
+    if (scenario.step_count == 0) {
+        pe_set_error(errbuf, errbuf_size, "scenario must contain at least one step");
+        return 0;
+    }
+
+    *out_scenario = scenario;
+    return 1;
+}


### PR DESCRIPTION
# PR Summary

Adds a minimal pricing engine and local ClickHouse integration for generating and storing market data.

## Includes:

- C-based pricing engine:
- deterministic quote generation from YAML scenarios
- NDJSON output (one event per line)
- YAML-driven scenario format for reproducible tests
- ClickHouse setup via Docker
- init.sql schema for quotes table
- ingestion script (push_input_to_db.sh) using JSONEachRow

## Usage:
```bash
./pricing_engine --scenario examples/basic_btc.yaml | ./push_input_to_db.sh
```

## Notes:
Designed as MVP for market data pipeline
Schema must be initialized once per fresh volume